### PR TITLE
Make file links clickable

### DIFF
--- a/lib/bk/commands/artifacts.rb
+++ b/lib/bk/commands/artifacts.rb
@@ -119,7 +119,7 @@ module Bk
 
             artifacts.each do |artifact|
               if download
-                puts "  - #{artifact.path} (downloading to tmp/bk/[filename])"
+                puts "  - Downloading artifact to tmp/bk/#{artifact.path}"
                 download_artifact(artifact)
               else
                 puts "  - #{artifact.path}"


### PR DESCRIPTION
This output is kind of annoying:
```
  - tmp/ci-artifacts/db_extraction/transactions/01884f05-513f-4a07-813c-fd71ec36476f-results.yml (downloading to tmp/bk/[filename])
```

There's nothing to click!

By having the actual artifact path there, we can click on it using our editor/terminal shortcuts.
