### PR TITLE
Add standardrb to CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,4 @@
-name: Tests
+name: CI
 
 on:
   pull_request:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,4 +16,4 @@ jobs:
           bundler: default
           bundler-cache: true
       - name: StandardRb check
-        run: bundle exec standardrb --format progress --format github --color
+        run: bundle exec standardrb --format progress --format github --color --no-fix

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,19 @@
+name: Tests
+
+on:
+  pull_request:
+    branches:
+      - "*"
+jobs:
+  linters:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.2
+          bundler: default
+          bundler-cache: true
+      - name: StandardRb check
+        run: bundle exec standardrb --format progress --format github --color

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,4 +16,4 @@ jobs:
           bundler: default
           bundler-cache: true
       - name: StandardRb check
-        run: bundle exec standardrb --format progress --format github --color --no-fix
+        run: bundle exec standardrb --format progress --format github --color

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -99,6 +99,7 @@ GEM
     sorbet-static (0.5.10871-universal-darwin-20)
     sorbet-static (0.5.10871-universal-darwin-21)
     sorbet-static (0.5.10871-universal-darwin-22)
+    sorbet-static (0.5.10871-x86_64-linux)
     sorbet-static-and-runtime (0.5.10871)
       sorbet (= 0.5.10871)
       sorbet-runtime (= 0.5.10871)
@@ -170,6 +171,7 @@ PLATFORMS
   arm64-darwin-20
   arm64-darwin-21
   arm64-darwin-22
+  x86_64-linux
 
 DEPENDENCIES
   buildkite-cli!

--- a/lib/bk.rb
+++ b/lib/bk.rb
@@ -16,8 +16,8 @@ require "dry/cli"
 require "cgi"
 
 require_relative "bk/version"
-require 'parallel'
-require 'ruby-progressbar'
+require "parallel"
+require "ruby-progressbar"
 
 module Bk
   class Error < StandardError; end

--- a/lib/bk/commands/artifacts.rb
+++ b/lib/bk/commands/artifacts.rb
@@ -80,16 +80,16 @@ module Bk
         include Color
 
         def path
-          self.artifact.path
+          artifact.path
         end
 
         def download_url
-          self.artifact.to_h["downloadURL"]
+          artifact.to_h["downloadURL"]
         end
 
         def header
-          color = job_colors[self.job_exit_status]
-          base_header = color.call(self.job_label)
+          color = job_colors[job_exit_status]
+          base_header = color.call(job_label)
           if parallel_notation == ""
             base_header
           else
@@ -111,7 +111,7 @@ module Bk
         has_next_page = true
 
         while has_next_page
-          result = query(BuildArtifactsQuery, variables: { slug: slug, jobs_after: jobs_after })
+          result = query(BuildArtifactsQuery, variables: {slug: slug, jobs_after: jobs_after})
 
           build = result.data.build
           # only show the first time
@@ -132,7 +132,7 @@ module Bk
           # %B – The full progress bar including 'incomplete' space
           # %j – Percentage complete represented as a whole number, right justified to 3 spaces
           # %E – Estimated time (will fall back to ETA: > 4 Days when it exceeds 99:00:00)
-          bar = ProgressBar.create(total: jobs.count, throttle_rate: 1, format: '%a %t [%c/%C BK jobs]: %B %j%%, %E')
+          bar = ProgressBar.create(total: jobs.count, throttle_rate: 1, format: "%a %t [%c/%C BK jobs]: %B %j%%, %E")
           bar.log "Fetching artifact paths for #{jobs.count} jobs..."
           all_matching_artifacts = []
 
@@ -144,10 +144,10 @@ module Bk
             next unless artifacts.any?
 
             artifacts.each do |artifact|
-              if job.parallel_group_index && job.parallel_group_total
-                parallel_notation = "(#{job.parallel_group_index + 1}/#{job.parallel_group_total})"
+              parallel_notation = if job.parallel_group_index && job.parallel_group_total
+                "(#{job.parallel_group_index + 1}/#{job.parallel_group_total})"
               else
-                parallel_notation = ""
+                ""
               end
 
               all_matching_artifacts << DownloadableArtifact.new(
@@ -161,7 +161,7 @@ module Bk
 
           if download
             bar.log "Now downloading #{all_matching_artifacts.count} artifacts!"
-            bar = ProgressBar.create(total: all_matching_artifacts.count, throttle_rate: 1, format: '%a %t [%c/%C artifacts]: %B %j%%, %E')
+            bar = ProgressBar.create(total: all_matching_artifacts.count, throttle_rate: 1, format: "%a %t [%c/%C artifacts]: %B %j%%, %E")
             Parallel.each(all_matching_artifacts, in_threads: 8) do |artifact|
               download_artifact(artifact, bar)
               bar.increment


### PR DESCRIPTION
I saw some of the files weren't linted with standardb. We already have a `lefthook.yml` for pre-commit hooks, this enforces it at the PR level.

Can add this to the list of required once it is merged.